### PR TITLE
Feature: Create & Delete Endpoints for Crop and Soil Types

### DIFF
--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -11,7 +11,7 @@ from models import User, Dataset, SoilTypeValues
 from schemas import Dataset as DatasetScheme
 from schemas import WeightScheme
 from schemas import Message
-from schemas import IrrigationDatapoints, SoilTypeCreate, SoilTypeValuesScheme
+from schemas import IrrigationDatapoints, SoilTypeCreate
 from crud import dataset as crud_dataset
 from api.deps import get_jwt
 
@@ -101,7 +101,7 @@ def get_soil_types(
     return [row[0] for row in soil_types]
 
 
-@router.post("/soil-types/", response_model=SoilTypeValuesScheme, dependencies=[Depends(deps.get_jwt)])
+@router.post("/soil-types/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def create_soil_type(
         soil_type_in: SoilTypeCreate,
         db: Session = Depends(deps.get_db)
@@ -122,9 +122,8 @@ def create_soil_type(
     )
     db.add(db_obj)
     db.commit()
-    db.refresh(db_obj)
 
-    return db_obj
+    return Message(message=f"Soil type '{soil_type_in.soil_type}' successfully added")
 
 
 @router.delete("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])

--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -101,7 +101,7 @@ def get_soil_types(
     return [row[0] for row in soil_types]
 
 
-@router.post("/soil-types/", response_model=SoilTypeValuesScheme, status_code=201, dependencies=[Depends(deps.get_jwt)])
+@router.post("/soil-types/", response_model=SoilTypeValuesScheme, dependencies=[Depends(deps.get_jwt)])
 def create_soil_type(
         soil_type_in: SoilTypeCreate,
         db: Session = Depends(deps.get_db)

--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -127,6 +127,27 @@ def create_soil_type(
     return db_obj
 
 
+@router.delete("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+def delete_soil_type(
+        soil_type: str,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Deletes a soil type by name.
+    """
+
+    normalized = soil_type.strip().lower().replace(" ", "_")
+
+    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == normalized).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Soil type '{soil_type}' not found")
+
+    db.delete(query_row)
+    db.commit()
+
+    return Message(message=f"Soil type '{normalized}' successfully deleted")
+
+
 @router.get("/{dataset_id}/", dependencies=[Depends(deps.get_jwt)])
 async def get_dataset(
         dataset_id: str,

--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -11,7 +11,7 @@ from models import User, Dataset, SoilTypeValues
 from schemas import Dataset as DatasetScheme
 from schemas import WeightScheme
 from schemas import Message
-from schemas import IrrigationDatapoints, SoilTypes
+from schemas import IrrigationDatapoints, SoilTypeCreate, SoilTypeValuesScheme
 from crud import dataset as crud_dataset
 from api.deps import get_jwt
 
@@ -101,6 +101,32 @@ def get_soil_types(
     return [row[0] for row in soil_types]
 
 
+@router.post("/soil-types/", response_model=SoilTypeValuesScheme, status_code=201, dependencies=[Depends(deps.get_jwt)])
+def create_soil_type(
+        soil_type_in: SoilTypeCreate,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Adds a new soil type with its field capacity and wilting point values.
+    Rejects the request if the soil type already exists.
+    """
+
+    exists = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil_type_in.soil_type).first()
+    if exists:
+        raise HTTPException(status_code=409, detail=f"Soil type '{soil_type_in.soil_type}' already exists")
+
+    db_obj = SoilTypeValues(
+        soil_type=soil_type_in.soil_type,
+        field_capacity=soil_type_in.field_capacity,
+        wilting_point=soil_type_in.wilting_point
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+
+    return db_obj
+
+
 @router.get("/{dataset_id}/", dependencies=[Depends(deps.get_jwt)])
 async def get_dataset(
         dataset_id: str,
@@ -138,7 +164,7 @@ def remove_dataset(
 def analyse_soil_moisture(
         dataset_id: str,
         db: Session = Depends(deps.get_db),
-        soil: Optional[SoilTypes] = None,
+        soil: Optional[str] = None,
         formatting: Literal["JSON", "JSON-LD"] = "JSON-LD"
 ):
     dataset: list[Dataset] = crud_dataset.get_datasets(db, dataset_id)
@@ -150,7 +176,7 @@ def analyse_soil_moisture(
     field_capacity = None
     wilting_point = None
     if soil:
-        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil.value).first()
+        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil).first()
         if query_row is None:
             raise HTTPException(status_code=404, detail="Soil type not found")
 
@@ -170,7 +196,7 @@ def analyse_soil_moisture(
 def get_irrigation_datapoints(
         dataset_id: str,
         db: Session = Depends(deps.get_db),
-        soil: Optional[SoilTypes] = None
+        soil: Optional[str] = None
 ):
     """
         Returns high dose irrigation datapoints for easier charts representation
@@ -184,7 +210,7 @@ def get_irrigation_datapoints(
     field_capacity = None
     wilting_point = None
     if soil:
-        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil.value).first()
+        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil).first()
         if query_row is None:
             raise HTTPException(status_code=404, detail="Soil type not found")
 

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -9,7 +9,7 @@ from api import deps
 import crud
 from api.deps import get_jwt
 
-from schemas import EToResponse, Calculation, Crop, KcStage
+from schemas import EToResponse, Calculation, KcStage, CropCreate, CropKcScheme, Message
 from models import CropKc
 from utils import jsonld_eto_response, fetch_parcel_by_id, fetch_parcel_lat_lon, TimeUnit, fetch_weather_data, fetch_historical_eto_for_location
 
@@ -35,13 +35,61 @@ def get_crop_types(
     }
 
 
+@router.post("/crop-types/", response_model=CropKcScheme, status_code=201, dependencies=[Depends(deps.get_jwt)])
+def create_crop_type(
+        crop_in: CropCreate,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Adds a new crop type with its Kc coefficients (init/mid/end).
+    Rejects the request if the crop already exists.
+    """
+
+    exists = db.query(CropKc).filter(CropKc.crop == crop_in.crop).first()
+    if exists:
+        raise HTTPException(status_code=409, detail=f"Crop '{crop_in.crop}' already exists")
+
+    db_obj = CropKc(
+        crop=crop_in.crop,
+        kc_init=crop_in.kc_init,
+        kc_mid=crop_in.kc_mid,
+        kc_end=crop_in.kc_end
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+
+    return db_obj
+
+
+@router.delete("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+def delete_crop_type(
+        crop: str,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Deletes a crop type by name.
+    """
+
+    normalized = crop.strip().lower().replace(" ", "_")
+
+    query_row = db.query(CropKc).filter(CropKc.crop == normalized).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Crop '{crop}' not found")
+
+    db.delete(query_row)
+    db.commit()
+
+    return Message(message=f"Crop '{normalized}' successfully deleted")
+
+
 @router.get("/get-calculations/{location_id}/from/{from_date}/to/{to_date}/", dependencies=[Depends(get_jwt)])
 def get_calculations(
     location_id: int,
     from_date: datetime.date,
     to_date: datetime.date,
     db: Session = Depends(deps.get_db),
-    crop: Optional[Crop] = None,
+    crop: Optional[str] = None,
     stage: Optional[KcStage] = None,
     formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):
@@ -65,7 +113,7 @@ def get_calculations(
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop.value).first()
+        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
         if kc_row is None:
             raise HTTPException(404, f"No KC coefficients found for crop {crop}")
 
@@ -107,7 +155,7 @@ def calculate_eto_via_gk(
         to_date: datetime.date,
         access_token: str = Depends(get_jwt),
         db: Session = Depends(deps.get_db),
-        crop: Optional[Crop] = None,
+        crop: Optional[str] = None,
         stage: Optional[KcStage] = None,
         formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):
@@ -144,7 +192,7 @@ def calculate_eto_via_gk(
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop.value).first()
+        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
         if kc_row is None:
             raise HTTPException(404, f"No KC coefficients found for crop {crop}")
 
@@ -187,7 +235,7 @@ def calculate_eto_by_coordinates(
         to_date: datetime.date,
         db: Session = Depends(deps.get_db),
         access_token: str = Depends(get_jwt),
-        crop: Optional[Crop] = None,
+        crop: Optional[str] = None,
         stage: Optional[KcStage] = None,
         formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):
@@ -219,7 +267,7 @@ def calculate_eto_by_coordinates(
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop.value).first()
+        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
         if kc_row is None:
             raise HTTPException(404, f"No KC coefficients found for crop {crop}")
 
@@ -256,7 +304,7 @@ def fetch_and_store_eto(
     from_date: datetime.date,
     to_date: datetime.date,
     db: Session = Depends(deps.get_db),
-    crop: Optional[Crop] = None,
+    crop: Optional[str] = None,
     stage: Optional[KcStage] = None,
     formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -9,7 +9,7 @@ from api import deps
 import crud
 from api.deps import get_jwt
 
-from schemas import EToResponse, Calculation, KcStage, CropCreate, CropKcScheme, Message
+from schemas import EToResponse, Calculation, KcStage, CropCreate, Message
 from models import CropKc
 from utils import jsonld_eto_response, fetch_parcel_by_id, fetch_parcel_lat_lon, TimeUnit, fetch_weather_data, fetch_historical_eto_for_location
 
@@ -35,7 +35,7 @@ def get_crop_types(
     }
 
 
-@router.post("/crop-types/", response_model=CropKcScheme, dependencies=[Depends(deps.get_jwt)])
+@router.post("/crop-types/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def create_crop_type(
         crop_in: CropCreate,
         db: Session = Depends(deps.get_db)
@@ -57,9 +57,8 @@ def create_crop_type(
     )
     db.add(db_obj)
     db.commit()
-    db.refresh(db_obj)
 
-    return db_obj
+    return Message(message=f"Crop '{crop_in.crop}' successfully added")
 
 
 @router.delete("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -35,7 +35,7 @@ def get_crop_types(
     }
 
 
-@router.post("/crop-types/", response_model=CropKcScheme, status_code=201, dependencies=[Depends(deps.get_jwt)])
+@router.post("/crop-types/", response_model=CropKcScheme, dependencies=[Depends(deps.get_jwt)])
 def create_crop_type(
         crop_in: CropCreate,
         db: Session = Depends(deps.get_db)

--- a/app/schemas/dataset_scheme.py
+++ b/app/schemas/dataset_scheme.py
@@ -89,11 +89,3 @@ class SoilTypeCreate(BaseModel):
     @classmethod
     def normalize_soil_type(cls, v: str) -> str:
         return v.strip().lower().replace(" ", "_")
-
-
-class SoilTypeValuesScheme(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    soil_type: str
-    field_capacity: float
-    wilting_point: float

--- a/app/schemas/dataset_scheme.py
+++ b/app/schemas/dataset_scheme.py
@@ -1,10 +1,9 @@
 import math
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, ConfigDict, Field, model_validator, field_validator
+from typing import List, Optional
 from datetime import datetime
 
-from enum import Enum
 
 class WeightScheme(BaseModel):
     val_10: float = Field(..., alias='10')
@@ -81,18 +80,20 @@ class IrrigationDatapoints(BaseModel):
     stress_level: float
 
 
-class SoilTypes(str, Enum):
-    SAND = "sand"
-    LOAMY_SAND = "loamy_sand"
-    SANDY_LOAM = "sandy_loam"
-    LOAM = "loam"
-    SILT_LOAM = "silt_loam"
-    SILT = "silt"
-    SANDY_CLAY_LOAM = "sandy_clay_loam"
-    CLAY_LOAM = "clay_loam"
-    SILTY_CLAY_LOAM = "silty_clay_loam"
-    SANDY_CLAY = "sandy_clay"
-    SILTY_CLAY = "silty_clay"
-    CLAY = "clay"
-    PEAT = "peat"
-    CHALK = "chalk"
+class SoilTypeCreate(BaseModel):
+    soil_type: str = Field(..., min_length=1, max_length=64)
+    field_capacity: float = Field(..., gt=0, lt=1)
+    wilting_point: float = Field(..., gt=0, lt=1)
+
+    @field_validator("soil_type")
+    @classmethod
+    def normalize_soil_type(cls, v: str) -> str:
+        return v.strip().lower().replace(" ", "_")
+
+
+class SoilTypeValuesScheme(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    soil_type: str
+    field_capacity: float
+    wilting_point: float

--- a/app/schemas/eto.py
+++ b/app/schemas/eto.py
@@ -1,13 +1,9 @@
 import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from enum import Enum
-
-class Crop(str, Enum):
-    sugar_beet = "sugar_beet"
-    potato = "potato"
 
 
 class KcStage(str, Enum):
@@ -48,3 +44,24 @@ class EtoCreate(BaseModel):
 
 class EtoUpdate(BaseModel):
     pass
+
+
+class CropCreate(BaseModel):
+    crop: str = Field(..., min_length=1, max_length=64)
+    kc_init: float = Field(..., gt=0, lt=2)
+    kc_mid: float = Field(..., gt=0, lt=2)
+    kc_end: float = Field(..., gt=0, lt=2)
+
+    @field_validator("crop")
+    @classmethod
+    def normalize_crop(cls, v: str) -> str:
+        return v.strip().lower().replace(" ", "_")
+
+
+class CropKcScheme(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    crop: str
+    kc_init: float
+    kc_mid: float
+    kc_end: float

--- a/app/schemas/eto.py
+++ b/app/schemas/eto.py
@@ -56,12 +56,3 @@ class CropCreate(BaseModel):
     @classmethod
     def normalize_crop(cls, v: str) -> str:
         return v.strip().lower().replace(" ", "_")
-
-
-class CropKcScheme(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    crop: str
-    kc_init: float
-    kc_mid: float
-    kc_end: float

--- a/app/utils/omutils.py
+++ b/app/utils/omutils.py
@@ -8,7 +8,7 @@ from retry_requests import retry
 from sqlalchemy.orm import Session
 
 import crud
-from schemas import EToResponse, Calculation, EtoCreate, Crop, KcStage
+from schemas import EToResponse, Calculation, EtoCreate, KcStage
 from models import CropKc
 
 cache_session = requests_cache.CachedSession('.cache', expire_after=3600)
@@ -23,13 +23,13 @@ def fetch_historical_eto_for_location(
         from_date: datetime.date,
         to_date: datetime.date,
         db: Session,
-        crop: Optional[Crop] = None,
+        crop: Optional[str] = None,
         stage: Optional[KcStage] = None,
 ) -> Optional[EToResponse]:
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop.value).first()
+        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
         if kc_row:
             if stage == KcStage.kc_init:
                 kc_value = kc_row.kc_init

--- a/app/utils/soil_analysis.py
+++ b/app/utils/soil_analysis.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Union, Tuple, Optional
 
 from schemas import Dataset as DatasetScheme
-from schemas import DatasetAnalysis, IrrigationDatapoints, DataPoints, SoilTypes
+from schemas import DatasetAnalysis, IrrigationDatapoints, DataPoints
 
 from datetime import datetime
 


### PR DESCRIPTION
Summary:
- Adds POST/DELETE endpoints for soil types (/api/v1/dataset/soil-types/{soil_type}/) and crop types (/api/v1/eto/crop-types/{crop}/), so new entries can be created and removed from the frontend instead of only via hardcoded config + app restart.
- Removes the static SoilTypes and Crop enums, since they'd go stale the moment a new type is inserted through the new endpoints. The soil/crop query params on the analysis/ETo endpoints now validate directly against the DB.

Tested:
- Manual end-to-end testing via curl/Postman: create, list, duplicate (409), delete, delete-again (404) for both soil types and crop types
- Verified crop/soil query params on existing analysis/ETo endpoints accept newly created values without enum-validation errors
- docker compose up --build — migrations + startup clean