### PR TITLE
Add PUT Endpoints for Crop & Soil Type Updates

### DIFF
--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -11,7 +11,7 @@ from models import User, Dataset, SoilTypeValues
 from schemas import Dataset as DatasetScheme
 from schemas import WeightScheme
 from schemas import Message
-from schemas import IrrigationDatapoints, SoilTypeCreate
+from schemas import IrrigationDatapoints, SoilTypeCreate, SoilTypeUpdate
 from crud import dataset as crud_dataset
 from api.deps import get_jwt
 
@@ -124,6 +124,40 @@ def create_soil_type(
     db.commit()
 
     return Message(message=f"Soil type '{soil_type_in.soil_type}' successfully added")
+
+
+@router.put("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+def update_soil_type(
+        soil_type: str,
+        soil_type_in: SoilTypeUpdate,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Updates a soil type's name and/or field capacity/wilting point values.
+    All fields are optional - only the provided ones are changed.
+    """
+
+    normalized = soil_type.strip().lower().replace(" ", "_")
+
+    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == normalized).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Soil type '{soil_type}' not found")
+
+    update_data = soil_type_in.model_dump(exclude_unset=True)
+
+    new_soil_type = update_data.pop("soil_type", None)
+    if new_soil_type is not None and new_soil_type != normalized:
+        exists = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == new_soil_type).first()
+        if exists:
+            raise HTTPException(status_code=409, detail=f"Soil type '{new_soil_type}' already exists")
+        query_row.soil_type = new_soil_type
+
+    for key, value in update_data.items():
+        setattr(query_row, key, value)
+
+    db.commit()
+
+    return Message(message=f"Soil type '{normalized}' successfully updated")
 
 
 @router.delete("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -9,7 +9,7 @@ from api import deps
 import crud
 from api.deps import get_jwt
 
-from schemas import EToResponse, Calculation, KcStage, CropCreate, Message
+from schemas import EToResponse, Calculation, KcStage, CropCreate, CropUpdate, Message
 from models import CropKc
 from utils import jsonld_eto_response, fetch_parcel_by_id, fetch_parcel_lat_lon, TimeUnit, fetch_weather_data, fetch_historical_eto_for_location
 
@@ -59,6 +59,40 @@ def create_crop_type(
     db.commit()
 
     return Message(message=f"Crop '{crop_in.crop}' successfully added")
+
+
+@router.put("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+def update_crop_type(
+        crop: str,
+        crop_in: CropUpdate,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Updates a crop's name and/or Kc coefficients (init/mid/end).
+    All fields are optional - only the provided ones are changed.
+    """
+
+    normalized = crop.strip().lower().replace(" ", "_")
+
+    query_row = db.query(CropKc).filter(CropKc.crop == normalized).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Crop '{crop}' not found")
+
+    update_data = crop_in.model_dump(exclude_unset=True)
+
+    new_crop = update_data.pop("crop", None)
+    if new_crop is not None and new_crop != normalized:
+        exists = db.query(CropKc).filter(CropKc.crop == new_crop).first()
+        if exists:
+            raise HTTPException(status_code=409, detail=f"Crop '{new_crop}' already exists")
+        query_row.crop = new_crop
+
+    for key, value in update_data.items():
+        setattr(query_row, key, value)
+
+    db.commit()
+
+    return Message(message=f"Crop '{normalized}' successfully updated")
 
 
 @router.delete("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])

--- a/app/schemas/dataset_scheme.py
+++ b/app/schemas/dataset_scheme.py
@@ -89,3 +89,22 @@ class SoilTypeCreate(BaseModel):
     @classmethod
     def normalize_soil_type(cls, v: str) -> str:
         return v.strip().lower().replace(" ", "_")
+
+
+class SoilTypeUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    soil_type: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    field_capacity: Optional[float] = Field(default=None, gt=0, lt=1)
+    wilting_point: Optional[float] = Field(default=None, gt=0, lt=1)
+
+    @field_validator("soil_type")
+    @classmethod
+    def normalize_soil_type(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip().lower().replace(" ", "_") if v is not None else v
+
+    @model_validator(mode="after")
+    def check_at_least_one_field(self) -> "SoilTypeUpdate":
+        if self.soil_type is None and self.field_capacity is None and self.wilting_point is None:
+            raise ValueError("At least one field must be provided to update")
+        return self

--- a/app/schemas/eto.py
+++ b/app/schemas/eto.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from enum import Enum
 
@@ -56,3 +56,23 @@ class CropCreate(BaseModel):
     @classmethod
     def normalize_crop(cls, v: str) -> str:
         return v.strip().lower().replace(" ", "_")
+
+
+class CropUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    crop: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    kc_init: Optional[float] = Field(default=None, gt=0, lt=2)
+    kc_mid: Optional[float] = Field(default=None, gt=0, lt=2)
+    kc_end: Optional[float] = Field(default=None, gt=0, lt=2)
+
+    @field_validator("crop")
+    @classmethod
+    def normalize_crop(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip().lower().replace(" ", "_") if v is not None else v
+
+    @model_validator(mode="after")
+    def check_at_least_one_field(self) -> "CropUpdate":
+        if self.crop is None and self.kc_init is None and self.kc_mid is None and self.kc_end is None:
+            raise ValueError("At least one field must be provided to update")
+        return self


### PR DESCRIPTION
Summary:
- Adds PUT /api/v1/dataset/soil-types/{soil_type}/ and PUT /api/v1/eto/crop-types/{crop}/ for updating existing soil/crop type values, including renaming.
- All fields in the request body are optional - only the fields present in the request are updated (partial update).
- Renaming to an already-existing name returns 409.
- Unknown fields in the body return 422.
- An empty body returns 422.

Tested:
- Manual curl test suite covering: partial update (single/multiple fields), rename, rename conflict (409), empty body (422), unknown field (422), out-of-range values (422), wrong type (422), nonexistent name in path (404), name normalization (case/whitespace), missing auth (401)
- docker compose up --build - migrations + startup clean