### PR TITLE
Add UUID Id to Soil/Crop Types and Switch Identifiers From Name to Id

### DIFF
--- a/alembic/versions/09ba0c74e019_add_uuid_id_to_soil_and_crop_types.py
+++ b/alembic/versions/09ba0c74e019_add_uuid_id_to_soil_and_crop_types.py
@@ -1,0 +1,53 @@
+"""Add UUID id to soil_type_values and crop_kc
+
+Revision ID: 09ba0c74e019
+Revises: 7c78a3ccee81
+Create Date: 2026-07-07 09:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '09ba0c74e019'
+down_revision: Union[str, None] = '7c78a3ccee81'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute('CREATE EXTENSION IF NOT EXISTS pgcrypto')
+
+    # --- soil_type_values ---
+    op.add_column('soil_type_values', sa.Column('id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.execute('UPDATE soil_type_values SET id = gen_random_uuid()')
+    op.alter_column('soil_type_values', 'id', nullable=False,
+                     server_default=sa.text('gen_random_uuid()'))
+    op.drop_constraint('soil_type_values_pkey', 'soil_type_values', type_='primary')
+    op.create_primary_key('soil_type_values_pkey', 'soil_type_values', ['id'])
+    op.create_unique_constraint('uq_soil_type_values_soil_type', 'soil_type_values', ['soil_type'])
+
+    # --- crop_kc ---
+    op.add_column('crop_kc', sa.Column('id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.execute('UPDATE crop_kc SET id = gen_random_uuid()')
+    op.alter_column('crop_kc', 'id', nullable=False,
+                     server_default=sa.text('gen_random_uuid()'))
+    op.drop_constraint('crop_kc_pkey', 'crop_kc', type_='primary')
+    op.create_primary_key('crop_kc_pkey', 'crop_kc', ['id'])
+    op.create_unique_constraint('uq_crop_kc_crop', 'crop_kc', ['crop'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_crop_kc_crop', 'crop_kc', type_='unique')
+    op.drop_constraint('crop_kc_pkey', 'crop_kc', type_='primary')
+    op.create_primary_key('crop_kc_pkey', 'crop_kc', ['crop'])
+    op.drop_column('crop_kc', 'id')
+
+    op.drop_constraint('uq_soil_type_values_soil_type', 'soil_type_values', type_='unique')
+    op.drop_constraint('soil_type_values_pkey', 'soil_type_values', type_='primary')
+    op.create_primary_key('soil_type_values_pkey', 'soil_type_values', ['soil_type'])
+    op.drop_column('soil_type_values', 'id')

--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -11,7 +11,7 @@ from models import User, Dataset, SoilTypeValues
 from schemas import Dataset as DatasetScheme
 from schemas import WeightScheme
 from schemas import Message
-from schemas import IrrigationDatapoints, SoilTypeCreate
+from schemas import IrrigationDatapoints, SoilTypeCreate, SoilTypeUpdate
 from crud import dataset as crud_dataset
 from api.deps import get_jwt
 
@@ -124,6 +124,40 @@ def create_soil_type(
     db.commit()
 
     return Message(message=f"Soil type '{soil_type_in.soil_type}' successfully added")
+
+
+@router.put("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+def update_soil_type(
+        soil_type: str,
+        soil_type_in: SoilTypeUpdate,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Updates a soil type's name and/or field capacity/wilting point values.
+    All fields are optional - only the provided ones are changed.
+    """
+
+    normalized = soil_type.strip().lower().replace(" ", "_")
+
+    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == normalized).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Soil type '{soil_type}' not found")
+
+    update_data = soil_type_in.model_dump(exclude_unset=True)
+
+    new_soil_type = update_data.pop("soil_type", None)
+    if new_soil_type is not None and new_soil_type != normalized:
+        exists = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == new_soil_type).first()
+        if exists:
+            raise HTTPException(status_code=409, detail=f"Soil type '{new_soil_type}' already exists")
+        query_row.soil_type = new_soil_type
+
+    for key, value in update_data.items():
+        setattr(query_row, key, value)
+
+    db.commit()
+
+    return Message(message=f"Soil type '{normalized}' successfully updated")
 
 
 @router.delete("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])

--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -100,6 +100,22 @@ def get_soil_types(
     return db.query(SoilTypeValues).all()
 
 
+@router.get("/soil-types/{soil_type_id}/", response_model=SoilTypeValuesScheme, dependencies=[Depends(deps.get_jwt)])
+def get_soil_type(
+        soil_type_id: uuid.UUID,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Returns a single soil type by id.
+    """
+
+    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.id == soil_type_id).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Soil type with id '{soil_type_id}' not found")
+
+    return query_row
+
+
 @router.post("/soil-types/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def create_soil_type(
         soil_type_in: SoilTypeCreate,

--- a/app/api/api_v1/endpoints/dataset.py
+++ b/app/api/api_v1/endpoints/dataset.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from typing import List, Literal, Optional
 
@@ -11,7 +12,7 @@ from models import User, Dataset, SoilTypeValues
 from schemas import Dataset as DatasetScheme
 from schemas import WeightScheme
 from schemas import Message
-from schemas import IrrigationDatapoints, SoilTypeCreate, SoilTypeUpdate
+from schemas import IrrigationDatapoints, SoilTypeCreate, SoilTypeUpdate, SoilTypeValuesScheme
 from crud import dataset as crud_dataset
 from api.deps import get_jwt
 
@@ -87,18 +88,16 @@ def upload_dataset(
     return Message(message="Successfully uploaded")
 
 
-@router.get("/soil-types/", response_model=List[str], dependencies=[Depends(deps.get_jwt)])
+@router.get("/soil-types/", response_model=List[SoilTypeValuesScheme], dependencies=[Depends(deps.get_jwt)])
 def get_soil_types(
         db: Session = Depends(deps.get_db)
 ):
     """
-    Returns a list of all available soil types (e.g., ['sand', 'loam', ...])
+    Returns a list of all available soil types, including their id.
     Used to populate dropdowns in the frontend.
     """
 
-    soil_types = db.query(SoilTypeValues.soil_type).all()
-
-    return [row[0] for row in soil_types]
+    return db.query(SoilTypeValues).all()
 
 
 @router.post("/soil-types/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
@@ -126,9 +125,9 @@ def create_soil_type(
     return Message(message=f"Soil type '{soil_type_in.soil_type}' successfully added")
 
 
-@router.put("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+@router.put("/soil-types/{soil_type_id}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def update_soil_type(
-        soil_type: str,
+        soil_type_id: uuid.UUID,
         soil_type_in: SoilTypeUpdate,
         db: Session = Depends(deps.get_db)
 ):
@@ -137,16 +136,14 @@ def update_soil_type(
     All fields are optional - only the provided ones are changed.
     """
 
-    normalized = soil_type.strip().lower().replace(" ", "_")
-
-    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == normalized).first()
+    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.id == soil_type_id).first()
     if query_row is None:
-        raise HTTPException(status_code=404, detail=f"Soil type '{soil_type}' not found")
+        raise HTTPException(status_code=404, detail=f"Soil type with id '{soil_type_id}' not found")
 
     update_data = soil_type_in.model_dump(exclude_unset=True)
 
     new_soil_type = update_data.pop("soil_type", None)
-    if new_soil_type is not None and new_soil_type != normalized:
+    if new_soil_type is not None and new_soil_type != query_row.soil_type:
         exists = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == new_soil_type).first()
         if exists:
             raise HTTPException(status_code=409, detail=f"Soil type '{new_soil_type}' already exists")
@@ -157,28 +154,27 @@ def update_soil_type(
 
     db.commit()
 
-    return Message(message=f"Soil type '{normalized}' successfully updated")
+    return Message(message=f"Soil type '{query_row.soil_type}' successfully updated")
 
 
-@router.delete("/soil-types/{soil_type}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+@router.delete("/soil-types/{soil_type_id}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def delete_soil_type(
-        soil_type: str,
+        soil_type_id: uuid.UUID,
         db: Session = Depends(deps.get_db)
 ):
     """
-    Deletes a soil type by name.
+    Deletes a soil type by id.
     """
 
-    normalized = soil_type.strip().lower().replace(" ", "_")
-
-    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == normalized).first()
+    query_row = db.query(SoilTypeValues).filter(SoilTypeValues.id == soil_type_id).first()
     if query_row is None:
-        raise HTTPException(status_code=404, detail=f"Soil type '{soil_type}' not found")
+        raise HTTPException(status_code=404, detail=f"Soil type with id '{soil_type_id}' not found")
 
+    deleted_name = query_row.soil_type
     db.delete(query_row)
     db.commit()
 
-    return Message(message=f"Soil type '{normalized}' successfully deleted")
+    return Message(message=f"Soil type '{deleted_name}' successfully deleted")
 
 
 @router.get("/{dataset_id}/", dependencies=[Depends(deps.get_jwt)])
@@ -218,7 +214,7 @@ def remove_dataset(
 def analyse_soil_moisture(
         dataset_id: str,
         db: Session = Depends(deps.get_db),
-        soil: Optional[str] = None,
+        soil: Optional[uuid.UUID] = None,
         formatting: Literal["JSON", "JSON-LD"] = "JSON-LD"
 ):
     dataset: list[Dataset] = crud_dataset.get_datasets(db, dataset_id)
@@ -230,7 +226,7 @@ def analyse_soil_moisture(
     field_capacity = None
     wilting_point = None
     if soil:
-        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil).first()
+        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.id == soil).first()
         if query_row is None:
             raise HTTPException(status_code=404, detail="Soil type not found")
 
@@ -250,7 +246,7 @@ def analyse_soil_moisture(
 def get_irrigation_datapoints(
         dataset_id: str,
         db: Session = Depends(deps.get_db),
-        soil: Optional[str] = None
+        soil: Optional[uuid.UUID] = None
 ):
     """
         Returns high dose irrigation datapoints for easier charts representation
@@ -264,7 +260,7 @@ def get_irrigation_datapoints(
     field_capacity = None
     wilting_point = None
     if soil:
-        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.soil_type == soil).first()
+        query_row = db.query(SoilTypeValues).filter(SoilTypeValues.id == soil).first()
         if query_row is None:
             raise HTTPException(status_code=404, detail="Soil type not found")
 

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -1,6 +1,7 @@
 import datetime
+import uuid
 
-from typing import Literal, Optional, List, Dict
+from typing import Literal, Optional, List
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -9,30 +10,22 @@ from api import deps
 import crud
 from api.deps import get_jwt
 
-from schemas import EToResponse, Calculation, KcStage, CropCreate, CropUpdate, Message
+from schemas import EToResponse, Calculation, KcStage, CropCreate, CropUpdate, CropKcScheme, Message
 from models import CropKc
 from utils import jsonld_eto_response, fetch_parcel_by_id, fetch_parcel_lat_lon, TimeUnit, fetch_weather_data, fetch_historical_eto_for_location
 
 router = APIRouter()
 
-@router.get("/option-types/", response_model=Dict[str, List[str]], dependencies=[Depends(deps.get_jwt)])
+@router.get("/option-types/", response_model=List[CropKcScheme], dependencies=[Depends(deps.get_jwt)])
 def get_crop_types(
     db: Session = Depends(deps.get_db)
 ):
     """
-    Returns Crop types from DB.
+    Returns Crop types from DB, including their id.
     Used to populate dropdowns in the frontend.
     """
 
-    crops_query = db.query(CropKc.crop).all()
-    crops_list = [row[0] for row in crops_query]
-
-    stages_list = [stage.value for stage in KcStage]
-
-    return {
-        "crops": crops_list,
-        "stages": stages_list
-    }
+    return db.query(CropKc).all()
 
 
 @router.post("/crop-types/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
@@ -61,9 +54,9 @@ def create_crop_type(
     return Message(message=f"Crop '{crop_in.crop}' successfully added")
 
 
-@router.put("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+@router.put("/crop-types/{crop_id}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def update_crop_type(
-        crop: str,
+        crop_id: uuid.UUID,
         crop_in: CropUpdate,
         db: Session = Depends(deps.get_db)
 ):
@@ -72,16 +65,14 @@ def update_crop_type(
     All fields are optional - only the provided ones are changed.
     """
 
-    normalized = crop.strip().lower().replace(" ", "_")
-
-    query_row = db.query(CropKc).filter(CropKc.crop == normalized).first()
+    query_row = db.query(CropKc).filter(CropKc.id == crop_id).first()
     if query_row is None:
-        raise HTTPException(status_code=404, detail=f"Crop '{crop}' not found")
+        raise HTTPException(status_code=404, detail=f"Crop with id '{crop_id}' not found")
 
     update_data = crop_in.model_dump(exclude_unset=True)
 
     new_crop = update_data.pop("crop", None)
-    if new_crop is not None and new_crop != normalized:
+    if new_crop is not None and new_crop != query_row.crop:
         exists = db.query(CropKc).filter(CropKc.crop == new_crop).first()
         if exists:
             raise HTTPException(status_code=409, detail=f"Crop '{new_crop}' already exists")
@@ -92,28 +83,27 @@ def update_crop_type(
 
     db.commit()
 
-    return Message(message=f"Crop '{normalized}' successfully updated")
+    return Message(message=f"Crop '{query_row.crop}' successfully updated")
 
 
-@router.delete("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+@router.delete("/crop-types/{crop_id}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def delete_crop_type(
-        crop: str,
+        crop_id: uuid.UUID,
         db: Session = Depends(deps.get_db)
 ):
     """
-    Deletes a crop type by name.
+    Deletes a crop type by id.
     """
 
-    normalized = crop.strip().lower().replace(" ", "_")
-
-    query_row = db.query(CropKc).filter(CropKc.crop == normalized).first()
+    query_row = db.query(CropKc).filter(CropKc.id == crop_id).first()
     if query_row is None:
-        raise HTTPException(status_code=404, detail=f"Crop '{crop}' not found")
+        raise HTTPException(status_code=404, detail=f"Crop with id '{crop_id}' not found")
 
+    deleted_name = query_row.crop
     db.delete(query_row)
     db.commit()
 
-    return Message(message=f"Crop '{normalized}' successfully deleted")
+    return Message(message=f"Crop '{deleted_name}' successfully deleted")
 
 
 @router.get("/get-calculations/{location_id}/from/{from_date}/to/{to_date}/", dependencies=[Depends(get_jwt)])
@@ -122,7 +112,7 @@ def get_calculations(
     from_date: datetime.date,
     to_date: datetime.date,
     db: Session = Depends(deps.get_db),
-    crop: Optional[str] = None,
+    crop: Optional[uuid.UUID] = None,
     stage: Optional[KcStage] = None,
     formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):
@@ -146,7 +136,7 @@ def get_calculations(
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
+        kc_row = db.query(CropKc).filter(CropKc.id == crop).first()
         if kc_row is None:
             raise HTTPException(404, f"No KC coefficients found for crop {crop}")
 
@@ -188,7 +178,7 @@ def calculate_eto_via_gk(
         to_date: datetime.date,
         access_token: str = Depends(get_jwt),
         db: Session = Depends(deps.get_db),
-        crop: Optional[str] = None,
+        crop: Optional[uuid.UUID] = None,
         stage: Optional[KcStage] = None,
         formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):
@@ -225,7 +215,7 @@ def calculate_eto_via_gk(
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
+        kc_row = db.query(CropKc).filter(CropKc.id == crop).first()
         if kc_row is None:
             raise HTTPException(404, f"No KC coefficients found for crop {crop}")
 
@@ -268,7 +258,7 @@ def calculate_eto_by_coordinates(
         to_date: datetime.date,
         db: Session = Depends(deps.get_db),
         access_token: str = Depends(get_jwt),
-        crop: Optional[str] = None,
+        crop: Optional[uuid.UUID] = None,
         stage: Optional[KcStage] = None,
         formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):
@@ -300,7 +290,7 @@ def calculate_eto_by_coordinates(
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
+        kc_row = db.query(CropKc).filter(CropKc.id == crop).first()
         if kc_row is None:
             raise HTTPException(404, f"No KC coefficients found for crop {crop}")
 
@@ -337,7 +327,7 @@ def fetch_and_store_eto(
     from_date: datetime.date,
     to_date: datetime.date,
     db: Session = Depends(deps.get_db),
-    crop: Optional[str] = None,
+    crop: Optional[uuid.UUID] = None,
     stage: Optional[KcStage] = None,
     formatting: Literal["JSON", "JSON-LD"] = "JSON"
 ):

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -9,7 +9,7 @@ from api import deps
 import crud
 from api.deps import get_jwt
 
-from schemas import EToResponse, Calculation, KcStage, CropCreate, Message
+from schemas import EToResponse, Calculation, KcStage, CropCreate, CropUpdate, Message
 from models import CropKc
 from utils import jsonld_eto_response, fetch_parcel_by_id, fetch_parcel_lat_lon, TimeUnit, fetch_weather_data, fetch_historical_eto_for_location
 
@@ -59,6 +59,40 @@ def create_crop_type(
     db.commit()
 
     return Message(message=f"Crop '{crop_in.crop}' successfully added")
+
+
+@router.put("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
+def update_crop_type(
+        crop: str,
+        crop_in: CropUpdate,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Updates a crop's name and/or Kc coefficients (init/mid/end).
+    All fields are optional - only the provided ones are changed.
+    """
+
+    normalized = crop.strip().lower().replace(" ", "_")
+
+    query_row = db.query(CropKc).filter(CropKc.crop == normalized).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Crop '{crop}' not found")
+
+    update_data = crop_in.model_dump(exclude_unset=True)
+
+    new_crop = update_data.pop("crop", None)
+    if new_crop is not None and new_crop != normalized:
+        exists = db.query(CropKc).filter(CropKc.crop == new_crop).first()
+        if exists:
+            raise HTTPException(status_code=409, detail=f"Crop '{new_crop}' already exists")
+        query_row.crop = new_crop
+
+    for key, value in update_data.items():
+        setattr(query_row, key, value)
+
+    db.commit()
+
+    return Message(message=f"Crop '{normalized}' successfully updated")
 
 
 @router.delete("/crop-types/{crop}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])

--- a/app/api/api_v1/endpoints/eto.py
+++ b/app/api/api_v1/endpoints/eto.py
@@ -54,6 +54,22 @@ def create_crop_type(
     return Message(message=f"Crop '{crop_in.crop}' successfully added")
 
 
+@router.get("/crop-types/{crop_id}/", response_model=CropKcScheme, dependencies=[Depends(deps.get_jwt)])
+def get_crop_type(
+        crop_id: uuid.UUID,
+        db: Session = Depends(deps.get_db)
+):
+    """
+    Returns a single crop type by id.
+    """
+
+    query_row = db.query(CropKc).filter(CropKc.id == crop_id).first()
+    if query_row is None:
+        raise HTTPException(status_code=404, detail=f"Crop with id '{crop_id}' not found")
+
+    return query_row
+
+
 @router.put("/crop-types/{crop_id}/", response_model=Message, dependencies=[Depends(deps.get_jwt)])
 def update_crop_type(
         crop_id: uuid.UUID,

--- a/app/models/dataset_model.py
+++ b/app/models/dataset_model.py
@@ -1,4 +1,7 @@
+import uuid
+
 from sqlalchemy import Column, Integer, Float, Date, String
+from sqlalchemy.dialects.postgresql import UUID
 
 from db.base_class import Base
 
@@ -23,7 +26,8 @@ class Dataset(Base):
 class SoilTypeValues(Base):
     __tablename__ = "soil_type_values"
 
-    soil_type = Column(String, primary_key=True, unique=True, nullable=False)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False)
+    soil_type = Column(String, unique=True, nullable=False)
 
     field_capacity = Column(Float, nullable=False)
     wilting_point = Column(Float, nullable=False)

--- a/app/models/eto.py
+++ b/app/models/eto.py
@@ -1,4 +1,7 @@
+import uuid
+
 from sqlalchemy import Column, Integer, Date, ForeignKey, Float, String
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db.base_class import Base
@@ -6,7 +9,8 @@ from db.base_class import Base
 
 class CropKc(Base):
     __tablename__ = 'crop_kc'
-    crop = Column(String, primary_key=True, unique=True, nullable=False)
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False)
+    crop = Column(String, unique=True, nullable=False)
 
     kc_init = Column(Float, nullable=False)
     kc_mid = Column(Float, nullable=False)

--- a/app/schemas/dataset_scheme.py
+++ b/app/schemas/dataset_scheme.py
@@ -89,3 +89,22 @@ class SoilTypeCreate(BaseModel):
     @classmethod
     def normalize_soil_type(cls, v: str) -> str:
         return v.strip().lower().replace(" ", "_")
+
+
+class SoilTypeUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    soil_type: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    field_capacity: Optional[float] = Field(default=None, gt=0, lt=1)
+    wilting_point: Optional[float] = Field(default=None, gt=0, lt=1)
+
+    @field_validator("soil_type")
+    @classmethod
+    def normalize_soil_type(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip().lower().replace(" ", "_") if v is not None else v
+
+    @model_validator(mode="after")
+    def check_at_least_one_field(self) -> "SoilTypeUpdate":
+        if self.soil_type is None and self.field_capacity is None and self.wilting_point is None:
+            raise ValueError("At least one field must be provided to update")
+        return self

--- a/app/schemas/dataset_scheme.py
+++ b/app/schemas/dataset_scheme.py
@@ -1,4 +1,5 @@
 import math
+import uuid
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator, field_validator
 from typing import List, Optional
@@ -108,3 +109,12 @@ class SoilTypeUpdate(BaseModel):
         if self.soil_type is None and self.field_capacity is None and self.wilting_point is None:
             raise ValueError("At least one field must be provided to update")
         return self
+
+
+class SoilTypeValuesScheme(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    soil_type: str
+    field_capacity: float
+    wilting_point: float

--- a/app/schemas/eto.py
+++ b/app/schemas/eto.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from enum import Enum
 
@@ -56,3 +56,23 @@ class CropCreate(BaseModel):
     @classmethod
     def normalize_crop(cls, v: str) -> str:
         return v.strip().lower().replace(" ", "_")
+
+
+class CropUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    crop: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    kc_init: Optional[float] = Field(default=None, gt=0, lt=2)
+    kc_mid: Optional[float] = Field(default=None, gt=0, lt=2)
+    kc_end: Optional[float] = Field(default=None, gt=0, lt=2)
+
+    @field_validator("crop")
+    @classmethod
+    def normalize_crop(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip().lower().replace(" ", "_") if v is not None else v
+
+    @model_validator(mode="after")
+    def check_at_least_one_field(self) -> "CropUpdate":
+        if self.crop is None and self.kc_init is None and self.kc_mid is None and self.kc_end is None:
+            raise ValueError("At least one field must be provided to update")
+        return self

--- a/app/schemas/eto.py
+++ b/app/schemas/eto.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -76,3 +77,13 @@ class CropUpdate(BaseModel):
         if self.crop is None and self.kc_init is None and self.kc_mid is None and self.kc_end is None:
             raise ValueError("At least one field must be provided to update")
         return self
+
+
+class CropKcScheme(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    crop: str
+    kc_init: float
+    kc_mid: float
+    kc_end: float

--- a/app/utils/omutils.py
+++ b/app/utils/omutils.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from datetime import timezone, timedelta
 from typing import Optional
 
@@ -23,13 +24,13 @@ def fetch_historical_eto_for_location(
         from_date: datetime.date,
         to_date: datetime.date,
         db: Session,
-        crop: Optional[str] = None,
+        crop: Optional[uuid.UUID] = None,
         stage: Optional[KcStage] = None,
 ) -> Optional[EToResponse]:
 
     kc_value = None
     if crop and stage:
-        kc_row = db.query(CropKc).filter(CropKc.crop == crop).first()
+        kc_row = db.query(CropKc).filter(CropKc.id == crop).first()
         if kc_row:
             if stage == KcStage.kc_init:
                 kc_value = kc_row.kc_init


### PR DESCRIPTION
Summary:
- Adds a UUID primary key (id) to soil_type_values and crop_kc. The name columns (soil_type, crop) become unique but are no longer the primary key.
- PUT/DELETE endpoints for soil and crop types now identify the row by id instead of by name.
- Adds GET /dataset/soil-types/{soil_type_id}/ and GET /eto/crop-types/{crop_id}/ to fetch a single record by id.
- The soil/crop query params on the analysis and ETo calculation endpoints (analysis, irrigation-datapoints, get-calculations, calculate-gk, calculate-coordinates, fetch-and-store-eto) now also take an id instead of a name - this makes them stable across renames, since a type's name can now change without breaking the reference.
- GET /dataset/soil-types/ and GET /eto/option-types/ now return the id alongside each entry; the crop list endpoint no longer returns a separate stages field.

Test:
- Full CRUD test suite for soil/crop types (create, list, get-by-id, partial update, rename, rename-conflict, delete, delete-again)
- Calculation endpoints tested with valid id, nonexistent id (404), invalid UUID format (422), and old name-based calls (422)
- Regression pass on unrelated endpoints (dataset, location) - unaffected
- docker compose up --build - migration applies cleanly on existing _random_uuid())